### PR TITLE
Fix transparency lines with sonokai colorscheme

### DIFF
--- a/extensions/visual_cfg.vim
+++ b/extensions/visual_cfg.vim
@@ -11,13 +11,12 @@ let g:airline#extensions#tabline#right_sep = "\uE0BE"
 if has('termguicolors')
 	set termguicolors
 endif
+
 " The configuration options should be placed before `colorscheme sonokai`.
 let g:sonokai_style = 'andromeda'
 let g:sonokai_enable_italic = 1
 let g:sonokai_disable_italic_comment = 1
 let g:sonokai_transparent_background = 0
-
-colorscheme sonokai
 
 hi HighlightedyankRegion cterm=reverse gui=reverse
 
@@ -26,4 +25,5 @@ set background=dark " use dark mode
 
 hi Normal guibg=NONE ctermbg=NONE
 
+colorscheme sonokai
 


### PR DESCRIPTION
Com o `colorscheme  sonokai` as linhas com conteúdo ficavam transparentes mesmo com `let g:sonokai_transparent_background = 1`

Movi `colorscheme sonokai` para o final do arquivo, pois precisa ser setado após `hi Normal guibg=NONE ctermbg=NONE`, tornando o comportamento como o esperado, ou seja, setar `sonokai_transparent_background` para `1` torna completamente transparente e setar para `0` torna completamente opaco.