### PR TITLE
Fix changing shortcuts to mappings

### DIFF
--- a/extensions/features_cfg.vim
+++ b/extensions/features_cfg.vim
@@ -65,20 +65,3 @@ let g:NERDToggleCheckAllLines = 1
 " Vimspector
 let g:vimspector_enable_mappings = 'VISUAL_STUDIO'
 let g:vimspector_install_gadgets = []
-
-" Buffers shortcuts
-" To open a new empty buffer
-nmap <silent> <leader>{ :enew<cr>
-
-" Move to the next buffer
-nmap <silent> <leader>] :bnext<CR>
-
-" Move to the previous buffer
-nmap <silent> <leader>[ :bprevious<CR>
-
-" Close the current buffer and move to the previous one
-" This replicates the idea of closing a tab
-nmap <silent> <leader>} :bp <BAR> bd #<CR>
-
-" Show all open buffers and their status
-" nmap <leader>bl :ls<CR>

--- a/extensions/mappings.vim
+++ b/extensions/mappings.vim
@@ -15,5 +15,21 @@ nnoremap <silent> <leader>t :Leaderf bufTag<CR>
 
 nmap <silent> <F8> :TagbarToggle<CR>
 
-nmap <silent> <leader>bd :bd<CR>
+nmap <silent> <leader>bd :bd #<CR>
 
+" Buffers shortcuts
+" To open a new empty buffer
+nmap <silent> <leader>{ :enew<cr>
+
+" Move to the next buffer
+nmap <silent> <leader>] :bnext<CR>
+
+" Move to the previous buffer
+nmap <silent> <leader>[ :bprevious<CR>
+
+" Close the current buffer and move to the previous one
+" This replicates the idea of closing a tab
+nmap <silent> <leader>} :bp <BAR> bd #<CR>
+
+" Show all open buffers and their status
+" nmap <leader>bl :ls<CR>


### PR DESCRIPTION
Corrige os atalhos para mover entre os buffers para o local certo em [mappings.vim](../../blob/feature/buffers-shortcuts/extensions/mappings.vim)
Matem o atalho `<leader>bd` mas garante que ele não vai fechar o nvim.