### PR TITLE
Dockerized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ FROM ubuntu:latest
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ="America/Sao_Paulo"
 
-RUN apt-get update && apt-get install git curl nodejs neovim -y
+RUN apt-get update && apt-get install git curl nodejs neovim gnupg2 -y
 
 RUN sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt install yarn -y
 
 COPY . /root/.config/nvim/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG TZ="America/Sao_Paulo"
+# ARG TZ="America/Sao_Paulo"
 
-RUN apt-get update && apt-get install git curl nodejs neovim gnupg2 -y
-
-RUN sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
-       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+RUN apt-get update && apt-get -yq install git curl nodejs neovim gnupg2 && \
+    sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim' && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt install yarn -y
+    apt-get install -yq yarn && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY . /root/.config/nvim/
 
@@ -17,4 +17,6 @@ RUN /usr/bin/nvim +'PlugInstall --sync' +qa
 
 WORKDIR /mnt/workdir
 
-CMD /usr/bin/nvim
+ENTRYPOINT [ "/usr/bin/nvim" ]
+
+CMD [ "/mnt/workdir" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN /usr/bin/nvim +'PlugInstall --sync' +qa
 
 WORKDIR /mnt/workdir
 
-ENTRYPOINT /usr/bin/nvim
+CMD /usr/bin/nvim


### PR DESCRIPTION
Tentei reduzir o tamanho da imagem e seguir algumas boas práticas de acordo com a documentação.
Setei o vim para o `entrypoint` e a pasta que será montada no volume para o `command`, assim o usuário pode montar o volume e abrir o nvim em um subdiretório.